### PR TITLE
Refs #12654 - make the rails 4 changes compatible with rails 3

### DIFF
--- a/app/lib/actions/base.rb
+++ b/app/lib/actions/base.rb
@@ -2,7 +2,7 @@ module Actions
   class Base < Dynflow::Action
 
     def task
-      @task ||= ::ForemanTasks::Task::DynflowTask.find_by!(:external_id => execution_plan_id)
+      @task ||= ::ForemanTasks::Task::DynflowTask.where(:external_id => execution_plan_id).first!
     end
 
     # This method says what data form input gets into the task details in Rest API

--- a/app/models/foreman_tasks/concerns/action_triggering.rb
+++ b/app/models/foreman_tasks/concerns/action_triggering.rb
@@ -130,7 +130,7 @@ module ForemanTasks
           if @dynflow_sync_action
             run.wait
             if run.value.error?
-              task = ForemanTasks::Task::DynflowTask.find_by!(:external_id => @execution_plan.id)
+              task = ForemanTasks::Task::DynflowTask.where(:external_id => @execution_plan.id).first!
               raise ForemanTasks::TaskError.new(task)
             end
           end

--- a/app/models/foreman_tasks/concerns/host_action_subject.rb
+++ b/app/models/foreman_tasks/concerns/host_action_subject.rb
@@ -22,8 +22,8 @@ module ForemanTasks
           hostname.try(:downcase!)
           certname.try(:downcase!)
 
-          host = certname.present? ? Host.find_by(:certname => certname) : nil
-          host ||= Host.find_by(:name => hostname)
+          host = certname.present? ? Host.where(:certname => certname).first : nil
+          host ||= Host.where(:name => hostname).first
           host ||= Host.new(:name => hostname, :certname => certname) if Setting[:create_new_host_when_facts_are_uploaded]
           if host
             # if we were given a certname but found the Host by hostname we should update the certname

--- a/app/models/foreman_tasks/recurring_logic.rb
+++ b/app/models/foreman_tasks/recurring_logic.rb
@@ -9,7 +9,11 @@ module ForemanTasks
     belongs_to :triggering
 
     has_many :tasks, :through => :task_group
-    has_many :task_groups, -> { uniq }, :through => :tasks
+    if Rails::VERSION::MAJOR < 4
+      has_many :task_groups, :through => :tasks, :uniq => true
+    else
+      has_many :task_groups, -> { uniq }, :through => :tasks
+    end
 
     validates :cron_line, :presence => true
 

--- a/app/models/foreman_tasks/task/dynflow_task.rb
+++ b/app/models/foreman_tasks/task/dynflow_task.rb
@@ -15,7 +15,7 @@ module ForemanTasks
       self.start_before   = data[:start_before] if data[:start_before]
       self.parent_task_id ||= begin
                                 if main_action.caller_execution_plan_id
-                                  DynflowTask.find_by!(:external_id => main_action.caller_execution_plan_id).id
+                                  DynflowTask.where(:external_id => main_action.caller_execution_plan_id).first!.id
                                 end
                               end
       self.label          ||= main_action.class.name

--- a/db/seeds.d/60-dynflow_proxy_feature.rb
+++ b/db/seeds.d/60-dynflow_proxy_feature.rb
@@ -1,2 +1,2 @@
-f = Feature.find_or_create_by(:name => 'Dynflow')
+f = Feature.where(:name => 'Dynflow').first_or_create
 raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?

--- a/db/seeds.d/61-foreman_tasks_bookmarks.rb
+++ b/db/seeds.d/61-foreman_tasks_bookmarks.rb
@@ -4,7 +4,7 @@ Bookmark.without_auditing do
     { :name => "failed", :query => "state = paused or result = error or result = warning" }
 
   ].each do |item|
-    next if Bookmark.find_by_name(item[:name])
+    next if Bookmark.where(:name => item[:name]).first
     next if audit_modified? Bookmark, item[:name]
     b = Bookmark.create({:controller => "foreman_tasks_tasks", :public => true}.merge(item))
     raise "Unable to create bookmark: #{format_errors b}" if b.nil? || b.errors.any?

--- a/lib/foreman_tasks.rb
+++ b/lib/foreman_tasks.rb
@@ -27,7 +27,7 @@ module ForemanTasks
           end),
           (on ::Dynflow::World::Triggered.(execution_plan_id: ~any, future: ~any) do |id, finished|
             finished.wait if async == false
-            ForemanTasks::Task::DynflowTask.find_by!(:external_id => id)
+            ForemanTasks::Task::DynflowTask.where(:external_id => id).first!
           end)
   end
 
@@ -43,6 +43,6 @@ module ForemanTasks
 
   def self.delay(action, delay_options, *args)
     result = dynflow.world.delay action, delay_options, *args
-    ForemanTasks::Task::DynflowTask.find_by_external_id!(result.id)
+    ForemanTasks::Task::DynflowTask.where(:external_id => result.id).first!
   end
 end

--- a/lib/foreman_tasks/dynflow/console_authorizer.rb
+++ b/lib/foreman_tasks/dynflow/console_authorizer.rb
@@ -4,7 +4,7 @@ module ForemanTasks
     def initialize(env)
       @rack_request          = Rack::Request.new(env)
       @user_id, @expires_at = @rack_request.session.values_at('user', 'expires_at')
-      @user                 = User.find_by(:id => @user_id) unless session_expired?
+      @user                 = User.where(:id => @user_id).first unless session_expired?
     end
 
     def allow?

--- a/lib/foreman_tasks/dynflow/persistence.rb
+++ b/lib/foreman_tasks/dynflow/persistence.rb
@@ -31,15 +31,15 @@ module ForemanTasks
         raise Foreman::Exception.new('Plan is delayed but the delay record is missing') if delayed_plan.nil?
         # TODO: Rework this
         delayed_plan = ::Dynflow::DelayedPlan.new_from_hash(ForemanTasks.dynflow.world, delayed_plan)
-        task = ::ForemanTasks::Task::DynflowTask.find_by_external_id(execution_plan_id)
+        task = ::ForemanTasks::Task::DynflowTask.where(:external_id => execution_plan_id).first
         task.update_from_dynflow(data.merge(:start_at => delayed_plan.start_at,
                                             :start_before => delayed_plan.start_before))
       when :planning
-        task = ::ForemanTasks::Task::DynflowTask.find_by_external_id(execution_plan_id)
+        task = ::ForemanTasks::Task::DynflowTask.where(:external_id => execution_plan_id).first
         task.update_from_dynflow(data)
         Lock.owner!(::User.current, task.id) if ::User.current
       else
-        if task = ::ForemanTasks::Task::DynflowTask.find_by(:external_id => execution_plan_id)
+        if task = ::ForemanTasks::Task::DynflowTask.where(:external_id => execution_plan_id).first
           unless task.state.to_s == data[:state].to_s
             task.update_from_dynflow(data)
           end

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -29,7 +29,7 @@ module ForemanTasks
           triggered = ForemanTasks.trigger(Support::DummyProxyAction, Support::DummyProxyAction.proxy, 'foo' => 'bar')
           Support::DummyProxyAction.proxy.task_triggered.wait(5)
 
-          task = ForemanTasks::Task.find_by_external_id(triggered.id)
+          task = ForemanTasks::Task.where(:external_id => triggered.id).first
           task.state.must_equal 'running'
           task.result.must_equal 'pending'
 

--- a/test/unit/actions/action_with_sub_plans_test.rb
+++ b/test/unit/actions/action_with_sub_plans_test.rb
@@ -40,7 +40,7 @@ module ForemanTasks
         triggered = ForemanTasks.trigger(ParentAction, user)
         raise triggered.error if triggered.respond_to?(:error)
         triggered.finished.wait(2)
-        ForemanTasks::Task.find_by_external_id(triggered.id)
+        ForemanTasks::Task.where(:external_id => triggered.id).first
       end
 
       specify "the sub-plan stores the information about its parent" do

--- a/test/unit/task_groups_test.rb
+++ b/test/unit/task_groups_test.rb
@@ -51,7 +51,7 @@ module ForemanTasks
           triggered = ForemanTasks.trigger(action_class, *args)
           raise triggered.error if triggered.respond_to?(:error)
           triggered.finished.wait
-          ForemanTasks::Task.find_by_external_id(triggered.id)
+          ForemanTasks::Task.where(:external_id => triggered.id).first
         end
       end
 


### PR DESCRIPTION
Let's simplify the upgrade and keep one wheel out of the rails 4 migration mechanism. Also, it will help remote execution team to not need to maintain two versions when keeping compatibility with latest stable release.